### PR TITLE
Sentinel support added and DELETE key with member

### DIFF
--- a/src/main/java/com/mapabc/api/Tile38Template.java
+++ b/src/main/java/com/mapabc/api/Tile38Template.java
@@ -33,6 +33,8 @@ public interface Tile38Template {
 
     public void aofShrink();
 
+    public String delEntry(String key, String member);
+
     public String intersects(String key, Element element);
 
     public String nearBy(String key, double lng, double lat, int length);

--- a/src/main/java/com/mapabc/api/Tile38TemplateImpl.java
+++ b/src/main/java/com/mapabc/api/Tile38TemplateImpl.java
@@ -104,6 +104,14 @@ public class Tile38TemplateImpl implements Tile38Template {
     }
 
     @Override
+    public String delEntry(String key, String member) {
+        if (StringUtil.isBlack(key) || StringUtil.isBlack(member)) {
+            return "key is not null";
+        }
+        return commands.delEntry(key,member);
+    }
+
+    @Override
     public String intersects(String key, Element element) {
         if (StringUtil.isBlack(key)) {
             return "key is not null";

--- a/src/main/java/com/mapabc/client/Tile38Client.java
+++ b/src/main/java/com/mapabc/client/Tile38Client.java
@@ -28,7 +28,6 @@ public class Tile38Client implements Serializable {
     private RedisClient client = null;
 
     private StatefulRedisConnection<String, String> connect = null;
-
     public Tile38Client() {
         client = this.createRedisClient("127.0.0.1", 9851);
         commands = this.createCommands(client, "");
@@ -37,6 +36,11 @@ public class Tile38Client implements Serializable {
     public Tile38Client(String host, int port, String passWord) {
         client = this.createRedisClient(host, port);
         commands = this.createCommands(client, passWord);
+    }
+
+    public Tile38Client(String sentinelHost, int sentinelPort, String password , String masterId) {
+        client = this.createRedisClient(sentinelHost , sentinelPort , password , masterId);
+        commands = this.createCommands(client, password);
     }
 
     public void close() {
@@ -78,6 +82,11 @@ public class Tile38Client implements Serializable {
 
     private RedisClient createRedisClient(String host, int port) {
         return RedisClient.create(RedisURI.create(host, port));
+    }
+
+    private RedisClient createRedisClient(String sentinelHost, int sentinelPort, String password , String masterId) {
+        RedisURI redisURI = RedisURI.Builder.sentinel(sentinelHost, sentinelPort, masterId, password).withDatabase(0).build();
+        return RedisClient.create(redisURI);
     }
 
 }

--- a/src/main/java/com/mapabc/commands/BatchedCommandType.java
+++ b/src/main/java/com/mapabc/commands/BatchedCommandType.java
@@ -221,7 +221,7 @@ public enum BatchedCommandType implements ProtocolKeyword {
     NEARBY,
     WITHIN,
     INTERSECTS,
-
+    SETHOOK,
     CLUSTER;
     public final byte[] bytes;
 

--- a/src/main/java/com/mapabc/commands/Tile38Commands.java
+++ b/src/main/java/com/mapabc/commands/Tile38Commands.java
@@ -66,6 +66,8 @@ public interface Tile38Commands extends Commands {
     @Command("AOFSHRINK")
     void aofShrink();
 
+    @Command("DEL ?0 ?1")
+    String delEntry(String key,String member);
 
     /******************************************************
      **                      查询                         **
@@ -287,7 +289,7 @@ public interface Tile38Commands extends Commands {
     String setElementWithField(String key, String id, String geojson , String fieldKeyName , String fieldValue);
 
 
-    @Command("SET ?0 ?1 OBJECT ?2 FIELD ?3 ?4 ?5 ?6")
+    @Command("SET ?0 ?1 OBJECT ?2 FIELD ?3 ?4 FIELD ?5 ?6")
     String setElementWithFields(String key, String id, String geojson , String field1KeyName , String field1Value , String field2KeyName , String field2Value);
 
     /**


### PR DESCRIPTION
If someone wants to use tile38 in HA mode, added support for Sentinel in the client. This will automatically reconnect to current LEADER for write operations. 
Also added DEL key member command which was not present. 
